### PR TITLE
Legibility improvements under cmd.exe

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -5,8 +5,8 @@ table = require 'text-table'
 # sign language
 isWin = process.platform is 'win32'
 warnSign = "#{if isWin then '' else '⚠'}"
-errSign = '✖'
-happySign = '✔'
+errSign = "#{if isWin then '×' else '✖'}"
+happySign = "#{if isWin then '√' else '✔'}"
 
 exports.reporter = (filename = '', results = []) ->
     errs = 0


### PR DESCRIPTION
Hi, the default colour for the message text (blue) is pretty much unreadable when using the reporter inside `cmd.exe` due to how dark it is, so I changed that to cyan. Also, both the tick and cross symbols render correctly (the tick is never used though!), although the warning symbol doesn't.
