### PR TITLE
Update to CoffeeLint's new external reporter style

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -8,7 +8,7 @@ warnSign = "#{if isWin then '' else '⚠'}"
 errSign = "#{if isWin then '' else '✖'}"
 happySign = "#{if isWin then '' else '✔'}"
 
-exports.reporter = (filename = '', results = []) ->
+reporter = (filename = '', results = []) ->
     errs = 0
     warns = 0
     ret = ''
@@ -51,4 +51,13 @@ exports.reporter = (filename = '', results = []) ->
     # print table and summary line(s)
     console.log ret + '\n'
 
-module.exports = exports
+module.exports = class StylishReporter
+    # Maintain backward compatibility from before CoffeeLint supported external
+    # reporters.
+    @reporter: reporter
+
+    constructor: (@errorReport, options = {}) ->
+
+    publish: ->
+        for filename, results of @errorReport.paths
+            reporter filename, results


### PR DESCRIPTION
```
coffeelint --reporter coffeelint-stylish src/coffeelint.coffee
```

I haven't published the next release of CoffeeLint yet, but it's going to support the above syntax for 3rd party reporters. Reporters can be installed as a project dependency or global. Project dependencies are preferred.

https://github.com/clutchski/coffeelint/commit/1edf536935d969e0efbc4d26836e6420298d4b03
